### PR TITLE
CompatHelper: add new compat entry for TimerOutputs at version 0.5, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 SpecialFunctions = "2"
+TimerOutputs = "0.5"
 julia = "^1.6.7"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `TimerOutputs` package to `0.5`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.