### PR TITLE
CompatHelper: add new compat entry for StaticArrays at version 1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 BasisSets = "0.1.1"
 SpecialFunctions = "2"
+StaticArrays = "1"
 TimerOutputs = "^0.5.0"
 julia = "^1.6.7"
 


### PR DESCRIPTION
This pull request sets the compat entry for the `StaticArrays` package to `1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.